### PR TITLE
Correct test result errors

### DIFF
--- a/iterating-over-collections/test/one-test.js
+++ b/iterating-over-collections/test/one-test.js
@@ -6,7 +6,7 @@ describe('iteratorFactory', function() {
   it('can be instantiated', function() {
     var factory = new iteratorFactory();
 
-    assert.equal(typeof factory, iteratorFactory);
+    assert.equal(typeof factory, "object");
   });
 
   it.skip('has a prototype function called `sum`', function() {
@@ -36,7 +36,7 @@ describe('iteratorFactory', function() {
 
     assert.equal(factory.sumAndSquare([1, 2, 3, 4, 5]), 225);
 
-    assert.equal(factory.sumAndSquare([10, 11, 12, 13, 14]), 730);
+    assert.equal(factory.sumAndSquare([10, 11, 12, 13, 14]), 3600);
   })
 
   it.skip('can filter out odd numbers from a collection of integers', function() {


### PR DESCRIPTION
<h2>Correct typeof comparison error</h2>
<p>On line 9, assert.equal uses typeof on the new instantiated object 'factory' from line 7. <br>Current code compares the typeof result to iteratorFactory defined on line 2.<br> iteratorFactory is the constructor function provided in the connected file.<p>
<h3>Issue: </h3> <p>The test fails because <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof">typeof returns a string of the operand provided</a> resulting in a string of "object", and iteratorFactory is mapped to a function.</p>
<h3>Proposed Change:</h3>
<p>Change the second argument in assert.equal on line 9 from iteratorFactory to the string "object"</p>
<p>assert.equal(typeof factory, iteratorFactory);  >>      assert.equal(typeof factory, "object");</p>
<hr>
<h2>Correct math error</h2>
<p>Line 39 is testing the sum and square function.</p>
<p>The function is given the group [10, 11, 12, 13, 14]. The function should sum the numbers provided and square.</p>
<h3>Issue:</h3>
<p>Test fails on line 39: 730 != 3600</p>
<p>According to line 39: <br>   assert.equal(factory.sumAndSquare([10, 11, 12, 13, 14]), 730);<br><br>
Expected result is 730, yet:<br>
10+11+12+13+14 = 60;<br>60<sup>2</sup> = 3600;<br>
  3600 != 730</p>
<h3>Proposed Change:</h3>
<p>Change the second argument in assert.equal on line 39 from 730 to 3600.</p>
<p>    assert.equal(factory.sumAndSquare([10, 11, 12, 13, 14]), 730);
 >>     assert.equal(factory.sumAndSquare([10, 11, 12, 13, 14]), 3600);
</p>