### PR TITLE
Update tests to be more robust

### DIFF
--- a/mythical-creatures/test/direwolf-test.js
+++ b/mythical-creatures/test/direwolf-test.js
@@ -41,7 +41,7 @@ describe('Direwolf', function () {
     var direwolf = new Direwolf('Shaggydog', 'Karhold', 'Smol Pupper');
 
     assert.equal(direwolf.name, 'Shaggydog');
-    assert.equal(direwolf.home, 'Karhold');    
+    assert.equal(direwolf.home, 'Karhold');
     assert.equal(direwolf.size, 'Smol Pupper');
   });
 
@@ -80,7 +80,7 @@ describe('Direwolf', function () {
     assert.deepEqual(direwolf.starksToProtect, []);
 
     direwolf.protect(stark);
-    assert.equal(direwolf.starksToProtect.length, 1);    
+    assert.equal(direwolf.starksToProtect.length, 1);
     assert.equal(direwolf.starksToProtect[0].name, 'Arya');
   });
 
@@ -107,7 +107,7 @@ describe('Direwolf', function () {
     direwolf2.protect(stark3);
     direwolf2.protect(stark4);
     direwolf2.protect(stark5);
-    
+
     assert.equal(direwolf1.starksToProtect.length, 2);
     assert.equal(direwolf1.starksToProtect[0].name, 'Sansa');
     assert.equal(direwolf1.starksToProtect[1].name, 'John');
@@ -130,7 +130,7 @@ describe('Direwolf', function () {
     var stark2 = new Stark('Sansa', 'Dorn');
 
     assert.equal(stark1.safe, false);
-    assert.equal(stark2.safe, false);    
+    assert.equal(stark2.safe, false);
 
     direwolf.protect(stark1);
     assert.equal(stark1.safe, true);

--- a/mythical-creatures/test/dragon-test.js
+++ b/mythical-creatures/test/dragon-test.js
@@ -19,6 +19,7 @@ describe('Dragon', function () {
 
   it.skip('should have a rider', function () {
     var dragon = new Dragon('Saphira', 'Eragon');
+    assert.equal(dragon.name, 'Saphira');
     assert.equal(dragon.rider, 'Eragon');
   });
 

--- a/mythical-creatures/test/hobbit-test.js
+++ b/mythical-creatures/test/hobbit-test.js
@@ -24,6 +24,7 @@ describe('Hobbit', function () {
 
   it.skip('should have an age', function() {
     var hobbit = new Hobbit('Meriadoc');
+    assert.equal(hobbit.name, 'Meriadoc');
     assert.equal(hobbit.age, 0);
   });
 

--- a/mythical-creatures/test/medusa-test.js
+++ b/mythical-creatures/test/medusa-test.js
@@ -18,8 +18,9 @@ describe('Medusa', function () {
     assert.equal(medusa.name, 'Bree');
   });
 
-  it.skip('should start with no statues', function()  {
+  it.skip('should start with no statues', function() {
     var medusa = new Medusa('Taytay');
+    assert.equal(medusa.name, 'Taytay');
     assert.deepEqual(medusa.statues, []);
   });
 

--- a/mythical-creatures/test/ogre-test.js
+++ b/mythical-creatures/test/ogre-test.js
@@ -33,7 +33,7 @@ describe('Ogre', function () {
     var human = new Human('Jane');
 
     assert.equal(human.name, 'Jane');
-    
+
     ogre.encounter(human);
     assert.equal(human.encounterCounter, 1);
   });
@@ -54,18 +54,18 @@ describe('Ogre', function () {
     var ogre = new Ogre('Brak');
     var human = new Human('Jane');
 
-    assert.equal(human.noticesOgre(), false); 
+    assert.equal(human.noticesOgre(), false);
 
-    ogre.encounter(human);      
-    ogre.encounter(human);      
-    ogre.encounter(human); 
+    ogre.encounter(human);
+    ogre.encounter(human);
+    ogre.encounter(human);
     assert.equal(human.noticesOgre(), true);
 
     ogre.encounter(human);
-    ogre.encounter(human); 
+    ogre.encounter(human);
     assert.equal(human.noticesOgre(), false);
 
-    ogre.encounter(human); 
+    ogre.encounter(human);
     assert.equal(human.noticesOgre(), true);
   });
 
@@ -100,9 +100,9 @@ describe('Ogre', function () {
     ogre.encounter(human);
     ogre.encounter(human);
     ogre.encounter(human);
-    ogre.encounter(human);    
     ogre.encounter(human);
-    
+    ogre.encounter(human);
+
     assert.equal(human.encounterCounter, 6);
     assert.equal(ogre.swings, 2);
     assert.equal(human.knockedOut, true);

--- a/mythical-creatures/test/pirate-test.js
+++ b/mythical-creatures/test/pirate-test.js
@@ -19,6 +19,7 @@ describe('Pirate', function () {
 
   it.skip('should be a scallywag by default', function() {
     var pirate = new Pirate('JeffBeard');
+    assert.equal(pirate.name, 'JeffBeard');
     assert.equal(pirate.job, 'Scallywag');
   });
 

--- a/mythical-creatures/test/unicorn-test.js
+++ b/mythical-creatures/test/unicorn-test.js
@@ -17,6 +17,11 @@ describe('Unicorn', function () {
     assert.equal(unicorn.name, 'Bree');
   });
 
+  it.skip('should be able to have a different name', function () {
+    var unicorn = new Unicorn('Pam');
+    assert.equal(unicorn.name, 'Pam');
+  });
+
   it.skip('should have a color', function() {
     var unicorn = new Unicorn('TayTay', 'blue');
     assert.equal(unicorn.color, 'blue');

--- a/mythical-creatures/test/vampire-test.js
+++ b/mythical-creatures/test/vampire-test.js
@@ -19,6 +19,7 @@ describe('Vampire', function() {
 
   it.skip('should have a pet bat as a default', function() {
     var vampire = new Vampire('Brittany');
+    assert.equal(vampire.name, 'Brittany');
     assert.equal(vampire.pet, 'bat');
   });
 

--- a/mythical-creatures/test/werewolf-test.js
+++ b/mythical-creatures/test/werewolf-test.js
@@ -15,7 +15,9 @@ describe('Werewolf', function () {
 
   it.skip('should have a name', function () {
     var werewolf = new Werewolf('Jorge');
+    var werewolf2 = new Werewolf('Sal');
     assert.equal(werewolf.name, 'Jorge');
+    assert.equal(werewolf2.name, 'Sal');
   });
 
   it.skip('should have a location', function () {


### PR DESCRIPTION
.name not being called again in most instances allowing folks to hardcode
a name once and pass all the subsequent tests with non-matching names
and remove trailing whitespace from direwolf and ogre tests