### PR TITLE
Fix typo and logic bug in Oregon Trails Gear test suite

### DIFF
--- a/oregon-trail/test/gear-test.js
+++ b/oregon-trail/test/gear-test.js
@@ -25,11 +25,11 @@ describe('Gear', function() {
     var clothes = new Gear('clothes');
     var invalid = new Gear('mp3 player');
 
-    var valid = ammunition.checkForValidity();
-    var invalid = invalid.checkForValidity();
+    var validWhenChecked = ammunition.checkForValidity();
+    var notValidWhenChecked = invalid.checkForValidity();
 
-    assert.equal(valid, 'Great, we\'ll need lots of ammunition!');
-    assert.equal(invalid, 'I don\`t think a mp3 player will help us.');
+    assert.equal(validWhenChecked, 'Great, we\'ll need lots of ammunition!');
+    assert.equal(notValidWhenChecked, 'I don\'t think a mp3 player will help us.');
 
     assert.equal(ammunition.type, 'ammunition');
     assert.equal(food.type, 'food');


### PR DESCRIPTION
 - in 3rd Gear test, changed backtick to single quote in the word `don't` in the return string

- in the 3rd Gear test, fixed logic bug.  `invalid` was declared as variable holding new instance then redeclared to hold value of checkValidity() invocation which allowed assertion on line 37 to pass without the user reassigning the type to null for invalid types